### PR TITLE
Workflow execution to the main branch 

### DIFF
--- a/.github/workflows/azure-static-web-apps-wonderful-pond-0213cc10f.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-pond-0213cc10f.yml
@@ -3,11 +3,11 @@ name: Azure Static Web Apps CI/CD
 on:
   push:
     branches:
-      - azure-staticwebapp
+      - main
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - azure-staticwebapp
+      - main
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
### What does this PR do?

This pull request adds the Azure Static Web Apps workflow file (*.yml) configured to run exclusively on the main branch.

### Why is this PR needed?

By restricting the workflow execution to the main branch, we ensure that the deployment to Azure Static Web Apps is triggered only when changes are pushed to the primary development branch. This helps maintain a controlled deployment pipeline and prevents accidental deployments from feature branches.